### PR TITLE
Feat/item stack

### DIFF
--- a/src/portal-slot/block.json
+++ b/src/portal-slot/block.json
@@ -15,6 +15,10 @@
 		"maxItems": {
 			"type": "number",
 			"default": 1
+		},
+		"rotate": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"example": {},

--- a/src/portal-slot/edit.js
+++ b/src/portal-slot/edit.js
@@ -10,6 +10,7 @@ import {
 	SelectControl,
 	ExternalLink,
 	Placeholder,
+	ToggleControl,
 	__experimentalNumberControl as NumberControl,
 } from "@wordpress/components";
 import { useSelect } from "@wordpress/data";
@@ -27,7 +28,7 @@ import "./editor.scss";
  * @return {Element} Element to render.
  */
 export default function Edit({ attributes, setAttributes }) {
-	const { slotId, maxItems } = attributes;
+	const { slotId, maxItems, rotate } = attributes;
 
 	// Fetch all terms from jcore-portal-slot taxonomy
 	const { terms, hasResolved } = useSelect((select) => {
@@ -85,6 +86,15 @@ export default function Edit({ attributes, setAttributes }) {
 					min={1}
 					help={__(
 						"Maximum number of campaign items to display.",
+						"jcore-portti",
+					)}
+				/>
+				<ToggleControl
+					label={__("Rotate items", "jcore-portti")}
+					checked={rotate}
+					onChange={(value) => setAttributes({ rotate: value })}
+					help={__(
+						"When enabled, items will rotate back to the start when running out of items in the stack.",
 						"jcore-portti",
 					)}
 				/>

--- a/src/portal-slot/render.php
+++ b/src/portal-slot/render.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $slot_id   = $attributes['slotId'] ?? '';
 $max_items = $attributes['maxItems'] ?? 1;
+$rotate    = $attributes['rotate'] ?? false;
 
 if ( empty( $slot_id ) ) {
 	if ( is_admin() ) {
@@ -23,7 +24,7 @@ if ( empty( $slot_id ) ) {
 	return;
 }
 
-$active_posts = get_active_portal_content( $slot_id, $max_items );
+$active_posts = get_active_portal_content( $slot_id, $max_items, $rotate );
 
 if ( ! empty( $active_posts ) ) {
 	foreach ( $active_posts as $active_post ) {


### PR DESCRIPTION
This pull request introduces a new "rotate" feature for portal slot content, allowing items to cycle back to the beginning when the stack is exhausted. The implementation touches backend logic, editor UI, and block attributes to support this behavior. The most important changes are grouped below.

**Backend logic enhancements:**

* The `get_active_portal_content` function in `inc/logic.php` now tracks the position in the item stack and supports the new `$rotate` parameter, enabling rotation through items when requested. It uses static variables to persist state across calls during a page load.
* The function `get_item_stack` was added to encapsulate filtering and sorting of portal items, returning all matches for a slot. The main function now delegates to this helper and always returns an array (never null). [[1]](diffhunk://#diff-460da55d2051fe4e33792186c4d84adb457e7f114fde05024652aaf945694234R17-R81) [[2]](diffhunk://#diff-460da55d2051fe4e33792186c4d84adb457e7f114fde05024652aaf945694234L85-R141) [[3]](diffhunk://#diff-460da55d2051fe4e33792186c4d84adb457e7f114fde05024652aaf945694234L121-L124) [[4]](diffhunk://#diff-460da55d2051fe4e33792186c4d84adb457e7f114fde05024652aaf945694234L145-L153)

**Block attribute and UI changes:**

* The block definition in `src/portal-slot/block.json` adds a new `rotate` boolean attribute, defaulting to false.
* The block editor UI in `src/portal-slot/edit.js` introduces a `ToggleControl` for the "Rotate items" option, allowing users to enable or disable rotation from the sidebar. [[1]](diffhunk://#diff-c431ee42a6598f4b16bc437f4a48caa78ffb142f51e4b3369eee12eaa0b0547aR13) [[2]](diffhunk://#diff-c431ee42a6598f4b16bc437f4a48caa78ffb142f51e4b3369eee12eaa0b0547aL30-R31) [[3]](diffhunk://#diff-c431ee42a6598f4b16bc437f4a48caa78ffb142f51e4b3369eee12eaa0b0547aR92-R100)

**Rendering logic update:**

* The server-side render function in `src/portal-slot/render.php` passes the new `rotate` attribute to `get_active_portal_content`, ensuring the frontend respects the rotation setting. [[1]](diffhunk://#diff-2832e9f5838a845569332d2cae6c94437271ea1ff0e7cd7dbe2cb9a9cf7bcfdeR16) [[2]](diffhunk://#diff-2832e9f5838a845569332d2cae6c94437271ea1ff0e7cd7dbe2cb9a9cf7bcfdeL26-R27)